### PR TITLE
Fix navigation crash when editing todos from TaskScreen

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/jadu/todoApp/ui/screens/navigations/BottomBarNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/io/jadu/todoApp/ui/screens/navigations/BottomBarNavigation.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.zIndex
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.toRoute
 import io.jadu.todoApp.ui.animatedBottomBar.CurvedBottomNavigation
 import io.jadu.todoApp.ui.animatedBottomBar.models.CurveAnimationType
 import io.jadu.todoApp.ui.animatedBottomBar.models.IconSource
@@ -26,6 +27,7 @@ import io.jadu.todoApp.ui.animatedBottomBar.models.NavItem
 import io.jadu.todoApp.ui.route.NavRoute
 import io.jadu.todoApp.ui.screens.AboutUsPage
 import io.jadu.todoApp.ui.screens.AddProject
+import io.jadu.todoApp.ui.screens.EditTodoScreen
 import io.jadu.todoApp.ui.screens.SettingsPage
 import io.jadu.todoApp.ui.screens.TaskScreen
 import io.jadu.todoApp.ui.screens.TestScreen
@@ -131,6 +133,14 @@ fun BottomBarNavigation(
 
                 composable<NavRoute.TestScreen> {
                     TestScreen()
+                }
+
+                composable<NavRoute.EditTodo> { backStackEntry ->
+                    val editTodoRoute = backStackEntry.toRoute<NavRoute.EditTodo>()
+                    EditTodoScreen(
+                        navController = navController,
+                        todoId = editTodoRoute.todoId
+                    )
                 }
             }
 


### PR DESCRIPTION
## Summary
  - Fixed IllegalArgumentException crash that occurred when tapping on a task in TaskScreen to edit it
  - Added missing EditTodo route to BottomBarNavigation NavHost
  - The route was only defined in MainScreenNavigation but TaskScreen resides in BottomBarNavigation

## Problem

  When users tapped on a todo item in the TaskScreen to edit it, the app crashed with:
  IllegalArgumentException: Destination with route EditTodo cannot be found in navigation graph

  This happened because:
  - TaskScreen is displayed within BottomBarNavigation
  - TaskScreen tries to navigate to NavRoute.EditTodo(todoId = todo.id) when a task is clicked
  - But the EditTodo route was only registered in MainScreenNavigation, not in BottomBarNavigation

##  Solution

  Added the EditTodo composable route to the BottomBarNavigation.kt NavHost, which:
  - Extracts the todoId parameter from the navigation route using toRoute<NavRoute.EditTodo>()
  - Passes the parameter to EditTodoScreen along with the navController

## Test plan

  - Tap on a todo item in TaskScreen
  - Verify that EditTodoScreen opens successfully without crashes
  - Verify that the correct todoId is passed to the edit screen
  - Test that navigation back from EditTodoScreen works correctly